### PR TITLE
drop node 18 and add 24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [ 18.x, 20.x, 22.x ]
+        node-version: [ 20.x, 22.x, 24.x ]
         os: [ ubuntu-latest, macOS-latest ]
 
     # Go

--- a/scripts/publish-layer.js
+++ b/scripts/publish-layer.js
@@ -24,7 +24,7 @@ try {
       let publish = new PublishLayerVersionCommand({
         Content: { ZipFile },
         LayerName,
-        CompatibleRuntimes: [ 'nodejs18.x', 'nodejs20.x', 'nodejs22.x' ],
+        CompatibleRuntimes: [ 'nodejs20.x', 'nodejs22.x', 'nodejs24.x' ],
         Description: 'Real-time Lambda telemetry, by Architect (arc.codes)',
         LicenseInfo: 'Apache-2.0',
       })


### PR DESCRIPTION
Node 18 is end of life as of Jan 2026 and  node 24 is supported.